### PR TITLE
Replace with simple import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+/.idea/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ intellij {
     version.set("2022.2.4")
     type.set("IC") // Target IDE Platform
 
-    plugins.set(listOf(/* Plugin Dependencies */))
+    plugins.set(listOf("Dart:222.4582"))
 }
 
 tasks {

--- a/src/main/kotlin/pl/digsa/flutter_arb_action/PanelDialog.kt
+++ b/src/main/kotlin/pl/digsa/flutter_arb_action/PanelDialog.kt
@@ -1,2 +1,15 @@
-package pl.digsa.flutter_arb_action 
+package pl.digsa.flutter_arb_action
 
+import com.intellij.openapi.ui.DialogWrapper
+import javax.swing.JComponent
+
+class PanelDialog(private val panel: JComponent, text: String) : DialogWrapper(true) {
+    init {
+        title = text
+        init()
+    }
+
+    override fun createCenterPanel() = panel
+
+    fun setOkText(text: String) = setOKButtonText(text)
+}

--- a/src/main/kotlin/pl/digsa/flutter_arb_action/ReplaceStringWithTranslationIntention.kt
+++ b/src/main/kotlin/pl/digsa/flutter_arb_action/ReplaceStringWithTranslationIntention.kt
@@ -1,4 +1,77 @@
 package pl.digsa.flutter_arb_action
 
-class ReplaceStringWithTranslationIntention {
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.childrenOfType
+import com.intellij.psi.util.parentOfType
+import com.intellij.psi.util.parents
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.dsl.builder.Cell
+import com.intellij.ui.dsl.builder.LabelPosition
+import com.intellij.ui.dsl.builder.panel
+import com.jetbrains.lang.dart.psi.DartExpression
+import com.jetbrains.lang.dart.psi.DartFile
+import com.jetbrains.lang.dart.psi.DartImportStatement
+import com.jetbrains.lang.dart.psi.DartMethodDeclaration
+import com.jetbrains.lang.dart.psi.DartSimpleFormalParameter
+import com.jetbrains.lang.dart.psi.DartStringLiteralExpression
+import com.jetbrains.lang.dart.util.DartElementGenerator
+
+
+@Suppress("IntentionDescriptionNotFoundInspection")
+class ReplaceStringWithTranslationIntention : PsiElementBaseIntentionAction(), IntentionAction {
+    override fun getFamilyName(): String = "Flutter resources"
+
+    override fun getText(): String = "Move to arb file"
+
+    override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean =
+        getStringLiteralExpression(element) != null && getBuildContextParameter(element) != null
+
+    private fun getStringLiteralExpression(element: PsiElement): DartStringLiteralExpression? =
+        element.parents(true).firstIsInstanceOrNull<DartStringLiteralExpression>()
+
+    private fun getBuildContextParameter(element: PsiElement): DartSimpleFormalParameter? {
+        val methodDeclaration = element.parents(false).firstIsInstanceOrNull<DartMethodDeclaration>() ?: return null
+        val normalFormalParameters = methodDeclaration.formalParameterList.normalFormalParameterList
+        return normalFormalParameters.firstOrNull { normalElement ->
+            normalElement.simpleFormalParameter?.text?.startsWith("BuildContext") ?: false
+        }?.simpleFormalParameter
+    }
+
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        val contextParameterName = getBuildContextParameter(element)?.text?.split(" ")?.last() ?: return
+        val stringLiteralExpression = getStringLiteralExpression(element) ?: return
+
+
+        lateinit var resourceName: Cell<JBTextField>
+        val panel = panel {
+            row {
+                resourceName = textField().label("Variable name", LabelPosition.TOP)
+            }
+        }
+
+        val popup = PanelDialog(panel, "Name arb variable")
+        popup.setOkText("Apply")
+        val isGenerate = popup.showAndGet()
+        if (!isGenerate)
+            return
+
+        val importStatement =
+            DartElementGenerator.createDummyFile(
+                project,
+                "import 'package:app/extensions/context_extensions.dart';"
+            ).firstChild
+        val dartFile = element.parentOfType<DartFile>()
+        val lastImportStatement = dartFile?.childrenOfType<DartImportStatement>()?.last()
+        dartFile?.addAfter(importStatement, lastImportStatement)
+
+        val replacementVersion: DartExpression = DartElementGenerator.createExpressionFromText(
+            project,
+            "$contextParameterName.text.${resourceName.component.text}"
+        ) ?: return
+        stringLiteralExpression.replace(replacementVersion)
+    }
 }

--- a/src/main/kotlin/pl/digsa/flutter_arb_action/extensions.kt
+++ b/src/main/kotlin/pl/digsa/flutter_arb_action/extensions.kt
@@ -1,2 +1,6 @@
 package pl.digsa.flutter_arb_action
 
+inline fun <reified R> Sequence<*>.firstIsInstanceOrNull(): R? {
+    for (element in this) if (element is R) return element
+    return null
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,18 +13,20 @@
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
          Simple HTML elements (text formatting, paragraphs, and lists) can be added inside of <![CDATA[ ]]> tag.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-description -->
-    <description><![CDATA[
-    Enter short description for your plugin here.<br>
-    <em>most HTML tags may be used</em>
-  ]]></description>
+    <description>Intention to move string text to arb files</description>
 
     <!-- Product and plugin compatibility requirements.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
-
+    <depends>Dart</depends>
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
+
+        <intentionAction>
+            <className>pl.digsa.flutter_arb_action.ReplaceStringWithTranslationIntention</className>
+            <category>Flutter resources</category>
+        </intentionAction>
 
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Replaces string literal with access to BuildContext with context.text.<> extension on AppLocalization and adds an import. 
For now it is import without logic, and puts a hardcoded one.